### PR TITLE
Use VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL in initialLayout for col…

### DIFF
--- a/src/engine/renderer/vk.cpp
+++ b/src/engine/renderer/vk.cpp
@@ -242,7 +242,7 @@ static VkRenderPass create_render_pass(VkDevice device, VkFormat color_format, V
 	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
 	attachments[1].flags = 0;


### PR DESCRIPTION
…or attachment.

Sometimes (in setup menu) rendering is done on top of previous frame. To ensure that contents of that frame won't be corrupted we shouldn't use undefined layout.